### PR TITLE
Correctly set HOST http header

### DIFF
--- a/server.js
+++ b/server.js
@@ -110,6 +110,9 @@ function processRequest(req, res)
 			}
 		}
 
+        //Set host header to remote host
+		req.headers["host"] = remoteURL.host;
+
 		var proxyRequest = request({
 			url: remoteURL,
 			headers: req.headers,


### PR DESCRIPTION
As I stated in issue1 (https://github.com/Freeboard/thingproxy/issues/1) thingproxy does not work if you request is to a server that uses the host header to differentiate between multiple web sites on the same server.

This commit just sets the HOST header on proxy request to the remote host and not the host that thingproxy is running on.